### PR TITLE
Refer "module" field to esm-compat

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Working around a Safari 14 IndexedDB bug",
   "homepage": "https://github.com/jakearchibald/safari-14-idb-fix",
   "main": "./dist/cjs-compat/index.js",
-  "module": "./dist/esm/index.js",
+  "module": "./dist/esm-compat/index.js",
   "types": "./dist/esm/index.d.ts",
   "exports": {
     ".": {


### PR DESCRIPTION
If I have interpreted the package.json fields conventions jungle correctly, the "module" field would be a way to point to an ES2015-based module but in all other aspects, only containing ES5-compatible JS code.

Found the issue as I integrated this module into dexie as a devDependencie, using rollup to include it. Rollup is run after transpilation and when it finds the "module" field, it integrates that module into my final ES5 code. When the CI tests sends this to browserstack for IE11 testing - it fails.

I don't know why I'm still maintaining dexie for IE11 though in 2021, but, I'm just in a minor release so I currently need to stick to it.