### PR TITLE
Type: module in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Working around a Safari 14 IndexedDB bug",
   "homepage": "https://github.com/jakearchibald/safari-14-idb-fix",
   "main": "./dist/cjs-compat/index.js",
+  "type": "module",
   "module": "./dist/esm-compat/index.js",
   "types": "./dist/esm/index.d.ts",
   "exports": {


### PR DESCRIPTION
Getting following error building a `sveltekit` project. Setting "type": "module" as suggested fixed it:

```
(node:51281) Warning: To load an ES module, set "type": "module" in the package.json or use the .mjs extension.
(Use `node --trace-warnings ...` to show where the warning was created)
> Cannot use import statement outside a module
/Users/holdph/personal/song-kit/node_modules/idb-keyval/dist/esm/index.js:1
import safariFix from 'safari-14-idb-fix';
^^^^^^

SyntaxError: Cannot use import statement outside a module
    at compileFunction (<anonymous>)
    at Object.compileFunction (node:vm:353:18)
    at wrapSafe (node:internal/modules/cjs/loader:1039:15)
    at Module._compile (node:internal/modules/cjs/loader:1073:27)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1138:10)
    at Module.load (node:internal/modules/cjs/loader:989:32)
    at Function.Module._load (node:internal/modules/cjs/loader:829:14)
    at ModuleWrap.<anonymous> (node:internal/modules/esm/translators:201:29)
    at ModuleJob.run (node:internal/modules/esm/module_job:175:25)
    at async Loader.import (node:internal/modules/esm/loader:178:24)
error Command failed with exit code 1.
```