### PR TITLE
Don't crash if navigator is unavailable

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,7 @@
  */
 export default function idbReady(): Promise<void> {
   const isSafari =
+    typeof navigator !== 'undefined' &&
     !navigator.userAgentData &&
     /Safari\//.test(navigator.userAgent) &&
     !/Chrom(e|ium)\//.test(navigator.userAgent);


### PR DESCRIPTION
_Note: I haven't tested this; I'm submitting it from the github editor._

When using [fake-indexeddb](https://www.npmjs.com/package/fake-indexeddb) with node (for unit testing), safari-14-idb-fix crashes with "ReferenceError: navigator is not defined". If navigator is not defined, then it clearly isn't safari, so I added the existence check.